### PR TITLE
Remove obsolete documentation for html_escape

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -15,9 +15,6 @@ class ERB
     # A utility method for escaping HTML tag characters.
     # This method is also aliased as <tt>h</tt>.
     #
-    # In your ERB templates, use this method to escape any unsafe content. For example:
-    #   <%= h @person.name %>
-    #
     #   puts html_escape('is a > 0 & a < 10?')
     #   # => is a &gt; 0 &amp; a &lt; 10?
     def html_escape(s)


### PR DESCRIPTION
There was out-of-date documentation for `h`/ `html_escape` that suggested you should use it in ERB templates to escape unsafe content. This has been unnecessary since Rails 3 started escaping everything by default.

If it would be better to replace it with a more up-to-date example instead of just removing it, let me know. I couldn't think of anything that added to the remaining documentation.

Resolves #30931.